### PR TITLE
Kata form validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kotlin training repository used to learn Kotlin and Functional Programming by so
 | # | Kata Statement | Topic |
 |---|----------------|-------|
 | 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/1) | Polymorphic programming |
-| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/3) | Validated data type|
+| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/4) | Validated data type|
 
 ### Executing tests:
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Kotlin training repository used to learn Kotlin and Functional Programming by so
 | # | Kata Statement |
 |---|----------------|
 | 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/1) |
+| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/2) |
 
 ### Executing tests:
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Kotlin training repository used to learn Kotlin and Functional Programming by so
 ### List of katas:
 
 
-| # | Kata Statement |
-|---|----------------|
-| 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/1) |
-| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/2) |
+| # | Kata Statement | Topic |
+|---|----------------|-------|
+| 1 | [Maxibons](https://github.com/Karumi/MaxibonKataJava#-kata-maxibon-for-java-) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/1) | Polymorphic programming |
+| 2 | [Form validation](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a) | [https://github.com/Karumi/KotlinKatas/pull/1](https://github.com/Karumi/KotlinKatas/pull/3) | Validated data type|
 
 ### Executing tests:
 

--- a/src/main/kotlin/com/github/pedrovgs/formvalidation/FormValidator.kt
+++ b/src/main/kotlin/com/github/pedrovgs/formvalidation/FormValidator.kt
@@ -1,0 +1,90 @@
+package com.github.pedrovgs.formvalidation
+
+import arrow.data.Validated
+import arrow.data.NonEmptyList
+import arrow.data.ValidatedNel
+import arrow.data.invalidNel
+import arrow.data.valid
+import arrow.data.extensions.nonemptylist.semigroup.semigroup
+import arrow.data.extensions.validated.applicative.applicative
+import arrow.data.fix
+import java.time.LocalDateTime
+
+typealias FormValidationResult<T> = ValidatedNel<FormError, T>
+
+object FormValidator {
+
+    fun validateForm(referenceDate: LocalDateTime, form: Form): FormValidationResult<Form> =
+            Validated.applicative(NonEmptyList.semigroup<FormError>()).tupled(
+                    validateFirstName(form.firstName),
+                    validateLastName(form.lastName),
+                    validateBirthday(referenceDate, form.birthday),
+                    validateDocumentId(form.documentId),
+                    validatePhoneNumber(form.phoneNumber),
+                    validateEmail(form.email)).fix().map {
+                Form(it.a, it.b, it.c, it.d, it.e, it.f)
+            }
+
+    private fun validateFirstName(firstName: String): FormValidationResult<String> =
+            if (firstName.trim().isNotEmpty()) {
+                Validated.Valid(firstName)
+            } else {
+                FormError.EmptyFirstName(firstName).invalidNel()
+            }
+
+    private fun validateLastName(lastName: String): FormValidationResult<String> =
+            if (lastName.trim().isNotEmpty()) {
+                lastName.valid()
+            } else {
+                FormError.EmptyLastName(lastName).invalidNel()
+            }
+
+    private fun validateBirthday(referenceDate: LocalDateTime, birthday: LocalDateTime): FormValidationResult<LocalDateTime> =
+            if (birthday <= referenceDate.minusYears(18)) {
+                birthday.valid()
+            } else {
+                FormError.UserTooYoung(birthday).invalidNel()
+            }
+
+    private fun validateDocumentId(documentId: String): FormValidationResult<String> =
+            if (documentRegex.matches(documentId)) {
+                documentId.valid()
+            } else {
+                FormError.InvalidDocumentId(documentId).invalidNel()
+            }
+
+    private fun validatePhoneNumber(phoneNumber: String): FormValidationResult<String> =
+            if (phoneRegex.matches(phoneNumber)) {
+                phoneNumber.valid()
+            } else {
+                FormError.InvalidPhoneNumber(phoneNumber).invalidNel()
+            }
+
+    private fun validateEmail(email: String): FormValidationResult<String> =
+            if (email.contains("@")) {
+                email.valid()
+            } else {
+                FormError.InvalidEmail(email).invalidNel()
+            }
+
+    private val documentRegex = "\\d{8}[a-zA-Z]{1}".toRegex()
+    private val phoneRegex = "\\d{9}".toRegex()
+}
+
+data class Form(
+    val firstName: String,
+    val lastName: String,
+    val birthday: LocalDateTime,
+    val documentId: String,
+    val phoneNumber: String,
+    val email: String
+)
+
+sealed class FormError {
+    data class EmptyFirstName(val firstName: String) : FormError()
+    data class EmptyLastName(val firstName: String) : FormError()
+    data class UserTooYoung(val birthday: LocalDateTime) : FormError()
+    data class InvalidDocumentId(val documentId: String) : FormError()
+    data class InvalidPhoneNumber(val phoneNumber: String) : FormError()
+    data class InvalidEmail(val email: String) : FormError()
+}

--- a/src/main/kotlin/com/github/pedrovgs/formvalidation/FormValidator.kt
+++ b/src/main/kotlin/com/github/pedrovgs/formvalidation/FormValidator.kt
@@ -15,15 +15,15 @@ typealias FormValidationResult<T> = ValidatedNel<FormError, T>
 object FormValidator {
 
     fun validateForm(referenceDate: LocalDateTime, form: Form): FormValidationResult<Form> =
-            Validated.applicative(NonEmptyList.semigroup<FormError>()).tupled(
+            Validated.applicative(NonEmptyList.semigroup<FormError>()).map(
                     validateFirstName(form.firstName),
                     validateLastName(form.lastName),
                     validateBirthday(referenceDate, form.birthday),
                     validateDocumentId(form.documentId),
                     validatePhoneNumber(form.phoneNumber),
-                    validateEmail(form.email)).fix().map {
+                    validateEmail(form.email)) {
                 Form(it.a, it.b, it.c, it.d, it.e, it.f)
-            }
+            }.fix()
 
     private fun validateFirstName(firstName: String): FormValidationResult<String> =
             if (firstName.trim().isNotEmpty()) {

--- a/src/main/kotlin/com/github/pedrovgs/formvalidation/main.kt
+++ b/src/main/kotlin/com/github/pedrovgs/formvalidation/main.kt
@@ -1,0 +1,35 @@
+package com.github.pedrovgs.formvalidation
+
+import java.time.LocalDateTime
+
+fun main() {
+    val firstForm = Form(
+            firstName = "Pedro",
+            lastName = "Gómez",
+            birthday = LocalDateTime.MIN,
+            documentId = "48632500A",
+            phoneNumber = "677673299",
+            email = "pedro@karumi.com"
+    )
+    val firstFormValidationResult = FormValidator.validateForm(LocalDateTime.now(), firstForm)
+    println("First form validation result $firstFormValidationResult")
+    firstFormValidationResult.fold(
+            { println("Error found in the first form $it") },
+            { println("The first form is valid") }
+    )
+
+    val secondForm = Form(
+            firstName = "",
+            lastName = "     ",
+            birthday = LocalDateTime.MIN,
+            documentId = "48632592",
+            phoneNumber = "6777",
+            email = "pg"
+    )
+    val secondFormValidationResult = FormValidator.validateForm(LocalDateTime.now(), secondForm)
+    println("First form validation result $secondFormValidationResult")
+    secondFormValidationResult.fold(
+            { println("Error found in the second form $it") },
+            { println("The second form is valid") }
+    )
+}

--- a/src/test/kotlin/com/github/pedrovgs/formvalidator/FormValidatorSpec.kt
+++ b/src/test/kotlin/com/github/pedrovgs/formvalidator/FormValidatorSpec.kt
@@ -1,0 +1,66 @@
+package com.github.pedrovgs.formvalidator
+
+import arrow.data.NonEmptyList
+import arrow.data.invalid
+import com.github.pedrovgs.formvalidation.Form
+import com.github.pedrovgs.formvalidation.FormError
+import com.github.pedrovgs.formvalidation.FormValidator
+import io.kotlintest.matchers.boolean.shouldBeTrue
+import io.kotlintest.properties.forAll
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import java.time.LocalDateTime
+
+class FormValidatorSpec : StringSpec({
+    "should not validate an empty form where every field is wrong" {
+        val form = Form(
+                firstName = "",
+                lastName = "  ",
+                birthday = LocalDateTime.now(),
+                documentId = "48632500",
+                phoneNumber = "6799",
+                email = "pedro"
+        )
+
+        val result = FormValidator.validateForm(LocalDateTime.now(), form)
+
+        result.isInvalid.shouldBeTrue()
+        result.shouldBe(
+                NonEmptyList.of(
+                        FormError.InvalidEmail(form.email),
+                        FormError.InvalidPhoneNumber(form.phoneNumber),
+                        FormError.InvalidDocumentId(form.documentId),
+                        FormError.UserTooYoung(form.birthday),
+                        FormError.EmptyFirstName(form.firstName),
+                        FormError.EmptyLastName(form.lastName)
+                ).invalid()
+        )
+    }
+
+    "should not validate any form where just one field is invalid" {
+        val form = Form(
+                firstName = "Pedro",
+                lastName = "Gómez",
+                birthday = LocalDateTime.MIN,
+                documentId = "48632500A",
+                phoneNumber = "677673299",
+                email = "p"
+        )
+
+        val result = FormValidator.validateForm(LocalDateTime.now(), form)
+
+        result.isInvalid.shouldBeTrue()
+        result.shouldBe(
+                NonEmptyList.of(
+                        FormError.InvalidEmail(form.email)
+                ).invalid()
+        )
+    }
+
+    "should validate any form where all the fields are correct" {
+        val referenceDate = LocalDateTime.now()
+        forAll(Generators.FormGeneartor(referenceDate)) { form ->
+            FormValidator.validateForm(referenceDate, form).isValid
+        }
+    }
+})

--- a/src/test/kotlin/com/github/pedrovgs/formvalidator/Generators.kt
+++ b/src/test/kotlin/com/github/pedrovgs/formvalidator/Generators.kt
@@ -1,0 +1,27 @@
+package com.github.pedrovgs.formvalidator
+
+import com.github.pedrovgs.formvalidation.Form
+import io.kotlintest.properties.Gen
+import java.time.LocalDateTime
+
+object Generators {
+
+    class FormGeneartor(private val referenceDate: LocalDateTime) : Gen<Form> {
+        override fun constants(): Iterable<Form> = emptyList()
+
+        private val nonEmptyStringGen = { Gen.string().random().filter { it.isNotEmpty() } }
+        private val nomEmptyStringWithLetters = { nonEmptyStringGen().filter { it.any { char -> char.isLetter() } } }
+
+        override fun random(): Sequence<Form> =
+                generateSequence {
+                    Form(
+                            firstName = nonEmptyStringGen().first(),
+                            lastName = nonEmptyStringGen().first(),
+                            birthday = referenceDate.minusYears(Gen.choose(18L, 1000L).random().first()),
+                            documentId = "${Gen.choose(10000000, 99999999).random().first()}${nomEmptyStringWithLetters().first().first { it.isLetter() }}",
+                            phoneNumber = "${Gen.choose(100000000, 999999999).random().first()}",
+                            email = "${nonEmptyStringGen().first()}@${nonEmptyStringGen().first()}.${Gen.oneOf(Gen.constant("com"), Gen.constant("es"), Gen.constant("net")).random().first()}}"
+                    )
+                }
+    }
+}


### PR DESCRIPTION
### :tophat: What is the goal?

To solve a simple exercise using [Validated](https://arrow-kt.io/docs/arrow/data/validated/) data type. The exercise statement can be found [here](https://gist.github.com/pedrovgs/d83fe1f096928715a6f31946e557995a). In this exercise the main goal is to validate a form returning all the errors if there are some.

### How is it being implemented?

To implement this kata we've decided to use a simple but powerful abstraction. The ``Validated`` data type. ``Validated`` is really similar to ``Either``but can be used in a different way because of the ``Applicative`` instance Arrow provides. **Thanks to this applicative instance we can accumulate all the errors found during the form validation as if we were handling a ``Either<NonEmptyList<FormError>, Form>`` without any mutable or variable structure.**

**There is one main issue related to the use of validated but it's more related to Kotlin than Arrow itself.** When validating a form, most of the time we want to validate every field separately. This means we will have to write different functions of every field validation and we need to do this most of the time in a parallel way. **We want to validate all the fields at a time and not one by one.** However, the only way to do this in a friendly way is to use the ``parallelValidate`` method [Arrow documentation](https://arrow-kt.io/docs/arrow/data/validated/) suggests but doesn't include as part of the main library. The ideal way to do this should be something like:

```kotlin
fun validateForm(referenceDate: LocalDateTime, form: Form): FormValidationResult<Form> =    (validateFirstName(form.firstName),
    validateLastName(form.lastName),
    validateBirthday(referenceDate, form.birthday),
    validateDocumentId(form.documentId),
    vaidatePhoneNumber(form.phoneNumber)
    validateEmail(form.email)).mapN(Form)
  }
```

As we can't do this because transforming a ``TupleX`` into a ``Form`` instance or accumulating the ``FormError`` instances is not possible we had to use the ``Aplicative`` instance of ``Validated`` as follows:

```kotlin
 Validated.applicative(NonEmptyList.semigroup<FormError>()).map(
                    validateFirstName(form.firstName),
                    validateLastName(form.lastName),
                    validateBirthday(referenceDate, form.birthday),
                    validateDocumentId(form.documentId),
                    validatePhoneNumber(form.phoneNumber),
                    validateEmail(form.email)) {
                Form(it.a, it.b, it.c, it.d, it.e, it.f)
            }.fix()
```

As Kotlin doesn't support of implicit values, we have to specify what's the Semigroup implementation we are using and the applicative instance too:

``Validated.applicative(NonEmptyList.semigroup<FormError>())``

We will also solve this exercise in Scala using refined. You'll find how this solution is simpler because of the usage of refined types which automatically provides the ``Validated`` implementation for every field. You'll find the solution [here](https://github.com/pedrovgs/ScalaKatas). On the other hand, the Swift solution will be harder to read because of the syntax. You can find the solution [here](https://github.com/pedrovgs/SwiftKatas)

From the testing end, the usage of a random ``Form`` generators is really interesting for this exercise.`

*Disclaimer: I know the validation methods can be improved by using better regex or other libraries, but I just wanted to practice how to use Validated and not how to validate different input types. That's why I used a simpler version*

### How can it be tested?

Automatically! :robot: I've added some automated tests I'd recommend you to review :smiley:
